### PR TITLE
Added 'stopped' state for garage doors.

### DIFF
--- a/lib/liftmaster_myq/device/garage_door.rb
+++ b/lib/liftmaster_myq/device/garage_door.rb
@@ -25,6 +25,8 @@ module LiftmasterMyq::Device
         return "open"
       elsif state == "2"
         return "closed"
+      elsif state == "3"
+        return "stopped"
       elsif state == "4"
         return "opening"
       elsif state == "5"


### PR DESCRIPTION
The "stopped" state on garage doors (state code 3) was unaccounted for.

Thanks for writing this API by the way!  It's really helpful.
